### PR TITLE
Study the feature

### DIFF
--- a/server/vite.ts
+++ b/server/vite.ts
@@ -3,8 +3,9 @@ import fs from "fs";
 import path from "path";
 import { createServer as createViteServer, createLogger } from "vite";
 import { type Server } from "http";
-import viteConfig from "../vite.config";
+// import viteConfig from "../vite.config";
 import { nanoid } from "nanoid";
+import { fileURLToPath } from "url";
 
 const viteLogger = createLogger();
 
@@ -26,6 +27,9 @@ export async function setupVite(app: Express, server: Server) {
     allowedHosts: true as const,
   };
 
+  // Dynamically import Vite config only in development to avoid executing it in production builds
+  const viteConfig = (await import("../vite.config")).default;
+
   const vite = await createViteServer({
     ...viteConfig,
     configFile: false,
@@ -45,8 +49,9 @@ export async function setupVite(app: Express, server: Server) {
     const url = req.originalUrl;
 
     try {
+      const __dirname = fileURLToPath(new URL('.', import.meta.url));
       const clientTemplate = path.resolve(
-        import.meta.dirname,
+        __dirname,
         "..",
         "client",
         "index.html",
@@ -68,7 +73,8 @@ export async function setupVite(app: Express, server: Server) {
 }
 
 export function serveStatic(app: Express) {
-  const distPath = path.resolve(import.meta.dirname, "public");
+  const __dirname = fileURLToPath(new URL('.', import.meta.url));
+  const distPath = path.resolve(__dirname, "public");
 
   if (!fs.existsSync(distPath)) {
     throw new Error(


### PR DESCRIPTION
Fix server static serving and Vite config loading for production.

Prevents `TypeError [ERR_INVALID_ARG_TYPE]` by replacing `import.meta.dirname` with a Node-compatible path resolution and dynamically loading Vite config only in development.

---
<a href="https://cursor.com/background-agent?bcId=bc-6a952bac-2863-4a73-b7ac-6f377dec3beb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6a952bac-2863-4a73-b7ac-6f377dec3beb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

